### PR TITLE
Reverse numering

### DIFF
--- a/fetch.py
+++ b/fetch.py
@@ -91,14 +91,8 @@ if __name__ == "__main__":
 
         print("Fetching %s images for %s" % (len(imgs), role["title"]))
 
-        no_images = len(imgs)
-        img_no = no_images
-        for img in imgs:
-            print(
-                " - image {} ({}/{})".format(
-                    img["imageId"], no_images - img_no + 1, no_images
-                )
-            )
+        for img_no, img in enumerate(imgs, start=1):
+            print(" - image {} ({}/{})".format(img["imageId"], img_no, len(imgs)))
 
             # This is constructed from very few examples - I might be asking it
             # to crop things it should not...
@@ -110,8 +104,9 @@ if __name__ == "__main__":
             )
 
             req = urllib.request.Request(url=url)
-            filename = "{}-{:04d}-{}.jpg".format(role["title"], img_no, img["imageId"])
-            img_no = img_no - 1
+            filename = "{}-{:06d}-{}.jpg".format(
+                role["title"], int(1e4) - img_no, img["imageId"]
+            )
 
             with urllib.request.urlopen(req) as r, open(filename, "wb") as f:
                 if r.status != 200:

--- a/fetch_from_messages.py
+++ b/fetch_from_messages.py
@@ -84,13 +84,9 @@ if __name__ == "__main__":
 
     my_info = client.me_me_me()
 
-    conversationsIds = client._auth_request(
-        "GET", "/api/v2/conversations"
-    )
+    conversationsIds = client._auth_request("GET", "/api/v2/conversations")
 
-    img_number = 1
-
-    for conv_id in conversationsIds:
+    for img_number, conv_id in enumerate(conversationsIds, start=1):
         conversation = client._auth_request(
             "GET", "/api/v2/conversations/%s" % (conv_id["conversationId"])
         )
@@ -106,8 +102,9 @@ if __name__ == "__main__":
                 print("%s" % (url))
                 req = urllib.request.Request(url=url)
 
-                with urllib.request.urlopen(req) as r, open("%i.jpg" % (img_number), "wb") as f:
+                with urllib.request.urlopen(req) as r, open(
+                    "%i.jpg" % (img_number), "wb"
+                ) as f:
                     if r.status != 200:
                         raise "B0rked! %s" % body
                     shutil.copyfileobj(r, f)
-                img_number += 1


### PR DESCRIPTION
 * Numbers images in reverse, starting at 9999 and going backwards. That way, any new pictures won't cause everything to be re-numbered.
 * Clean up the fetch_from_messages.py script.