### PR TITLE
Download original image

### DIFF
--- a/src/famly_fetch/image.py
+++ b/src/famly_fetch/image.py
@@ -35,7 +35,7 @@ class Image(BaseImage):
 
     @property
     def url(self):
-        return f"{self.prefix}/{self.width}x{self.height}/{self.key}"
+        return f"{self.prefix}/{self.key}"
 
 
 @dataclass
@@ -61,4 +61,4 @@ class SecretImage(BaseImage):
 
     @property
     def url(self):
-        return f"{self.prefix}/{self.key}/{self.width}x{self.height}/{self.path}?expires={self.expires}"
+        return f"{self.prefix}/{self.key}/{self.path}?expires={self.expires}"


### PR DESCRIPTION
Undocumented, but requests without the dimensions pull the "source" (still processed, but closer to the original) image. Eyeballing the two shows this one has less artifacts.