### PR TITLE
Download All Feed Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ famly-fetch -f
 
 Images are organised into subdirectories named by the post date (e.g. `pictures/2026-02-19/`), so all photos from posts on the same day are grouped together.
 
+> **Important privacy notice:** Using `-f` will download *all* images from the nursery feed, including photos of other children who are not your own. These images are shared by the nursery within a trusted setting. As a user of this tool you are solely responsible for handling these images with care — keep them private, do not share them further, and ensure they are stored securely. Delete any images of other children if you do not need them.
+
 ### State management
 
 famly-fetch tracks downloaded images in a state file to avoid re-downloading them.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,34 @@ Fetch your (kid's) images from famly.co
 code base. If you create PRs with improvements or bugfixes, please make sure
 to test them before submitting them.**
 
+## Local Development
+
+To run the project locally from source:
+
+```bash
+git clone https://github.com/ileodo/famly-fetch.git
+cd famly-fetch
+python -m venv .venv
+```
+
+Activate the virtual environment:
+
+- **Windows:** `.venv\Scripts\activate`
+- **Mac/Linux:** `source .venv/bin/activate`
+
+Then install the package in editable mode:
+
+```bash
+pip install -e .
+famly-fetch
+```
+
+To deactivate the virtual environment when done:
+
+```bash
+deactivate
+```
+
 ## Get Started
 
 ```
@@ -36,6 +64,16 @@ data of all downloaded images by providing latitude and longitude values.
 The `--stop-on-existing` option is helpful if you wish to download
 images continously and just want to download what is new since last
 download.
+
+### Downloading all feed images
+
+The `-f` / `--feed` flag downloads all images from all nursery feed posts, regardless of likes or tags:
+
+```bash
+famly-fetch -f
+```
+
+Images are organised into subdirectories named by the post date (e.g. `pictures/2026-02-19/`), so all photos from posts on the same day are grouped together.
 
 ### State management
 
@@ -120,6 +158,18 @@ Options:
   --version                       Show the version and exit.
   --help                          Show this message and exit.
 ```
+
+## Known Issues
+
+### Connection reset error
+
+When downloading a large number of images, you may see:
+
+```
+An exception occurred: <urlopen error [WinError 10054] An existing connection was forcibly closed by the remote host>
+```
+
+This is caused by the Famly server closing the connection after too many requests. Simply re-run the same command — already downloaded images are tracked in `state.json` and will be skipped, so the download will resume from where it left off.
 
 ## Docker
 

--- a/src/famly_fetch/cli.py
+++ b/src/famly_fetch/cli.py
@@ -57,6 +57,12 @@ def get_version():
     help="Download images which is liked by the parents from all posts (in the feed)",
 )
 @click.option(
+    "-f",
+    "--feed",
+    is_flag=True,
+    help="Download all images from all posts (in the feed)",
+)
+@click.option(
     "-p",
     "--pictures-folder",
     envvar="FAMLY_PICTURES_FOLDER",
@@ -143,6 +149,7 @@ def main(
     notes: bool,
     messages: bool,
     liked: bool,
+    feed: bool,
     pictures_folder: Path,
     stop_on_existing: bool,
     user_agent: str,
@@ -206,6 +213,9 @@ def main(
 
         if liked:
             famly_downloader.download_images_from_feed(parent_ids)
+
+        if feed:
+            famly_downloader.download_all_images_from_feed()
 
     except Exception as e:
         click.secho(f"An exception occurred: {e}", fg="red")

--- a/src/famly_fetch/downloader.py
+++ b/src/famly_fetch/downloader.py
@@ -314,6 +314,55 @@ class FamlyDownloader:
 
         self.save_state()
 
+    def download_all_images_from_feed(self, batch_size=20, batch_pause=10):
+        click.secho("Downloading all images from feed posts...", fg="green")
+
+        cursor = None
+        older_than = None
+        batch_count = 0
+        while True:
+            click.echo("Fetching next 10 Posts")
+            response = self._apiClient.feed(
+                cursor=cursor, older_than=older_than, limit=10
+            )
+            if not response["feedItems"]:
+                break
+            last_item = response["feedItems"][-1]
+            cursor = last_item["feedItemId"]
+            older_than = last_item["createdDate"]
+            for feed_item in response["feedItems"]:
+                if not feed_item["originatorId"].startswith("Post:"):
+                    continue
+                create_date = feed_item["createdDate"]
+                for img_dict in feed_item["images"]:
+                    img = Image.from_dict(
+                        img_dict,
+                        date_override=create_date,
+                        text_override=feed_item["body"] if self.text_comments else None,
+                    )
+                    click.echo(f" - image {img.img_id} from post at {create_date}")
+
+                    if img.img_id in self.downloaded_images:
+                        click.secho(
+                            f"Image {img.img_id} already downloaded, {'stopping download' if self.stop_on_existing else 'skipping'}.",
+                            fg="yellow",
+                        )
+                        if self.stop_on_existing:
+                            return
+                        else:
+                            continue
+                    file_path = self.download_file_path(img, "post")
+                    self.fetch_image(img, file_path)
+                    self.mark_as_downloaded(img.img_id)
+                    self.save_state()
+                    batch_count += 1
+                    if batch_count % batch_size == 0:
+                        click.secho(
+                            f"Downloaded {batch_count} images, pausing {batch_pause}s...",
+                            fg="cyan",
+                        )
+                        time.sleep(batch_pause)
+
     def download_file_path(self, img: BaseImage, filename_prefix: str) -> Path:
         """Generate the file path for the downloaded image."""
 
@@ -327,7 +376,10 @@ class FamlyDownloader:
         filename = img.date.strftime(filename)
         filename = filename + file_ext
 
-        return Path(self._pictures_folder, filename)
+        date_dir = img.date.strftime("%Y-%m-%d")
+        dir_path = Path(self._pictures_folder, date_dir)
+        dir_path.mkdir(parents=True, exist_ok=True)
+        return Path(dir_path, filename)
 
     def fetch_image(self, img: BaseImage, file_path: Path):
         req = urllib.request.Request(url=img.url)


### PR DESCRIPTION
 Add -f flag to download all images from feed posts

  Summary

  - Adds -f / --feed flag to download all images from nursery feed posts regardless of likes or tags
  - Downloaded images are organised into date-based subdirectories (e.g. pictures/2026-02-19/) grouping photos by post date
  - state.json is saved after every image download so interrupted runs resume from where they left off rather than starting over
  - Adds 10s pause every 20 images to avoid connection resets from the server

  Changes

  - downloader.py — new download_all_images_from_feed() method with batching and per-image state persistence
  - downloader.py — download_file_path() now creates date subdirectories automatically
  - cli.py — new -f / --feed flag wired up
  - README.md — documented the new flag, date directories, connection reset known issue and local dev setup with venv