### PR TITLE
Add ability to fetch other files/videos that may be attached to notes/journeys/feed posts.

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,13 @@
+# Default image mapping for `act` in this repo.
+#
+# The stock catthehacker runner image has no `node` on PATH, which breaks the
+# JS actions (checkout, setup-python) and their post steps. We map
+# `ubuntu-latest` to a local image built from ci-local.Dockerfile that adds
+# Node.js 24.
+#
+# scripts/ci-local.sh builds this image automatically. To build it by hand for
+# direct `act` use:
+#   docker build -f ci-local.Dockerfile -t famly-fetch-act-runner:latest .
+-P ubuntu-latest=famly-fetch-act-runner:latest
+# The image is local-only; do not try to force-pull it from a registry.
+--pull=false

--- a/README.md
+++ b/README.md
@@ -39,6 +39,51 @@ To deactivate the virtual environment when done:
 deactivate
 ```
 
+## Running CI Locally
+
+The GitHub Actions workflow (`.github/workflows/ci.yml`) lints and format-checks
+the code across a matrix of Python versions (3.10, 3.11, 3.12, 3.13). You can
+reproduce that workflow on your own machine before pushing, using the
+`scripts/ci-local.sh` wrapper around [`act`](https://github.com/nektos/act).
+
+It runs the exact same steps as GitHub (checkout, set up Python, install
+dependencies, `ruff check`, `ruff format --diff`) inside Ubuntu containers, one
+per matrix entry, so any failure you see locally matches what CI will report.
+
+The workflow runs in a local Docker image built from `ci-local.Dockerfile`,
+which extends the standard `act` runner with Node.js (the stock image has no
+`node` on PATH, which the checkout and setup-python actions need). The wrapper
+builds this image automatically on first run.
+
+Requirements:
+
+- [`act`](https://github.com/nektos/act) (`brew install act` on macOS)
+- A running Docker daemon
+
+Usage:
+
+```bash
+# Run all four matrix builds (3.10-3.13) concurrently
+scripts/ci-local.sh
+
+# Run only the Python 3.11 build
+scripts/ci-local.sh -v 3.11
+
+# List the jobs without running them
+scripts/ci-local.sh -l
+
+# Rebuild the local runner image (e.g. after editing ci-local.Dockerfile)
+scripts/ci-local.sh -b
+
+# Pass extra flags straight through to act
+scripts/ci-local.sh -- --verbose
+```
+
+The first run builds the runner image, which can take a minute or two. On Apple
+silicon the script automatically requests the `linux/amd64` image so the
+containers match GitHub's runners. Run `scripts/ci-local.sh -h` for the full
+list of options.
+
 ## Get Started
 
 ```
@@ -86,6 +131,22 @@ You can customize the state file location using the `--state-file` option.
 
 If you need to start over, simply delete (or move) the state file.
 
+### Downloading non-image attachments and videos
+
+Use `--include-files` to download non-image file attachments (PDFs, documents, and similar files) from messages, notes, and learning journey entries:
+
+```bash
+famly-fetch --include-files
+```
+
+Use `--include-videos` to download videos from learning journey observations and feed posts:
+
+```bash
+famly-fetch --include-videos
+```
+
+Both flags can be combined with any other flags. They reuse the same `state.json` tracking and the same date-grouped folder layout as image downloads, so re-running will skip already-downloaded files. Non-image content is stored as-is without any EXIF metadata added.
+
 ### Customizing Filenames
 
 You can customize the filename format using the `--filename-pattern` option.
@@ -127,6 +188,13 @@ Options:
   -m, --messages                  Download images from messages
   -l, --liked                     Download images which is liked by the
                                   parents from all posts (in the feed)
+  -f, --feed                      Download all images from all posts (in the
+                                  feed)
+  --include-files                 Also download non-image file attachments
+                                  (PDFs, docs, etc.) from messages, notes, and
+                                  journeys
+  --include-videos                Also download videos from learning journey
+                                  observations and feed posts
   -p, --pictures-folder DIRECTORY
                                   Directory to save downloaded pictures, can
                                   be set via FAMLY_PICTURES_FOLDER env var

--- a/ci-local.Dockerfile
+++ b/ci-local.Dockerfile
@@ -1,0 +1,26 @@
+# Runner image for scripts/ci-local.sh.
+#
+# `act` runs the workflow inside catthehacker/ubuntu:act-latest, but that image
+# no longer ships a `node` binary on PATH. actions/checkout and
+# actions/setup-python are JavaScript actions whose main and post steps run via
+# `node`, so without it the job fails with:
+#   exec: "node": executable file not found in $PATH  (exit 127)
+#
+# This image extends the same base and installs Node.js 24 so those actions and
+# their post steps run cleanly. scripts/ci-local.sh builds it automatically.
+FROM catthehacker/ubuntu:act-latest
+
+ARG NODE_MAJOR=24
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
+        > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && node --version

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# ci-local.sh - run the GitHub Actions CI workflow (.github/workflows/ci.yml)
+# locally using `act`, reproducing the full Python version matrix as
+# concurrent container builds.
+#
+# Requirements: act (brew install act) and a running Docker daemon.
+
+# -e  exit on any error
+# -u  treat unset variables as errors
+# -o pipefail  a pipeline fails if any command in it fails
+set -euo pipefail
+
+# --- locate repo root (script lives in <root>/scripts) ---------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WORKFLOW=".github/workflows/ci.yml"
+
+# Runner image: the stock catthehacker image act uses has no `node` on PATH,
+# which breaks the JS actions (checkout, setup-python) and their post steps.
+# ci-local.Dockerfile extends it with Node.js 24; we build that locally and
+# point act at it. See ci-local.Dockerfile for details.
+RUNNER_DOCKERFILE="ci-local.Dockerfile"
+RUNNER_IMAGE="famly-fetch-act-runner:latest"
+
+# --- defaults --------------------------------------------------------------
+EVENT="pull_request"
+CONCURRENCY=4
+PY_VERSION=""
+LIST_ONLY=0
+REBUILD=0
+# Declared empty up front so the variable exists under `set -u`. Because an
+# empty array still trips "unbound variable" on bash 3.2, every expansion of
+# it below is guarded by a ${#EXTRA_ARGS[@]} length check.
+EXTRA_ARGS=()
+
+usage() {
+    # Here-doc avoids fragile sed-over-source-file parsing.
+    cat <<'EOF'
+ci-local.sh - run the GitHub Actions CI workflow (.github/workflows/ci.yml)
+locally using `act`, reproducing the full Python version matrix as
+concurrent container builds.
+
+This is a faithful local mirror of "Python CI": it runs the exact same
+steps (checkout, setup-python, install deps, ruff check, ruff format
+--diff) inside ubuntu containers, one per matrix entry, so failures seen
+here match what GitHub reports.
+
+Usage:
+  scripts/ci-local.sh                 # run all matrix builds (3.10-3.13)
+  scripts/ci-local.sh -v 3.11         # run only the Python 3.11 build
+  scripts/ci-local.sh -e push         # use the push event (default: pull_request)
+  scripts/ci-local.sh -c 2            # limit concurrent jobs (default: 4)
+  scripts/ci-local.sh -l              # list the jobs without running them
+  scripts/ci-local.sh -b              # force a rebuild of the runner image
+  scripts/ci-local.sh -- --verbose    # pass any extra args straight to act
+
+Options:
+  -v, --version VERSION   restrict the matrix to a single Python version
+  -e, --event   EVENT     act event trigger (default: pull_request)
+  -c, --concurrency N     maximum concurrent jobs (default: 4, must be a number)
+  -l, --list              list jobs without running them
+  -b, --rebuild           rebuild the local runner image before running
+  -h, --help              show this help and exit
+
+Requirements: act (brew install act) and a running Docker daemon.
+
+The workflow runs in a local image (ci-local.Dockerfile) that extends the
+catthehacker runner with Node.js, which the stock image lacks. The image is
+built automatically on first run; use -b to rebuild it.
+EOF
+}
+
+# --- arg parsing -----------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -v|--version)
+            PY_VERSION="${2:?--version requires a value, e.g. 3.11}"
+            shift 2
+            ;;
+        -e|--event)
+            EVENT="${2:?--event requires a value, e.g. push}"
+            shift 2
+            ;;
+        -c|--concurrency)
+            CONCURRENCY="${2:?--concurrency requires a numeric value}"
+            # Reject non-numeric values early so act gets a sensible error.
+            if ! [[ "${CONCURRENCY}" =~ ^[0-9]+$ ]]; then
+                echo "error: --concurrency requires a positive integer, got: ${CONCURRENCY}" >&2
+                exit 2
+            fi
+            shift 2
+            ;;
+        -l|--list)
+            LIST_ONLY=1
+            shift
+            ;;
+        -b|--rebuild)
+            REBUILD=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            EXTRA_ARGS=("$@")
+            break
+            ;;
+        *)
+            echo "error: unknown option: $1" >&2
+            echo "Run with -h or --help for usage." >&2
+            exit 2
+            ;;
+    esac
+done
+
+# --- prerequisite checks ---------------------------------------------------
+if ! command -v act >/dev/null 2>&1; then
+    echo "error: 'act' is not installed." >&2
+    echo "  macOS:  brew install act" >&2
+    echo "  Linux:  https://github.com/nektos/act#installation" >&2
+    exit 127
+fi
+
+# docker info writes to stdout and stderr even on success; suppress both.
+if ! docker info >/dev/null 2>&1; then
+    echo "error: Docker daemon is not reachable. Start Docker and retry." >&2
+    exit 1
+fi
+
+# Verify the workflow file exists before handing off to act.
+if [[ ! -f "${REPO_ROOT}/${WORKFLOW}" ]]; then
+    echo "error: workflow file not found: ${REPO_ROOT}/${WORKFLOW}" >&2
+    exit 1
+fi
+
+# Verify the runner Dockerfile exists.
+if [[ ! -f "${REPO_ROOT}/${RUNNER_DOCKERFILE}" ]]; then
+    echo "error: runner Dockerfile not found: ${REPO_ROOT}/${RUNNER_DOCKERFILE}" >&2
+    exit 1
+fi
+
+# On ARM hosts (Apple silicon "arm64", Linux ARM "aarch64") the act runner
+# images are amd64; force the platform for both the build and the run so the
+# container matches GitHub's runners instead of falling back to emulation.
+PLATFORM_BUILD_ARGS=()
+ACT_ARCH_ARGS=()
+_arch="$(uname -m)"
+if [[ "${_arch}" == "arm64" || "${_arch}" == "aarch64" ]]; then
+    PLATFORM_BUILD_ARGS=(--platform linux/amd64)
+    ACT_ARCH_ARGS=(--container-architecture linux/amd64)
+fi
+unset _arch
+
+# --- ensure the Node-enabled runner image exists ---------------------------
+# Listing does not run containers, so skip the (slow) build for -l.
+if [[ "${LIST_ONLY}" -eq 0 ]]; then
+    if [[ "${REBUILD}" -eq 1 ]] || ! docker image inspect "${RUNNER_IMAGE}" >/dev/null 2>&1; then
+        echo "==> Building runner image ${RUNNER_IMAGE} from ${RUNNER_DOCKERFILE}"
+        docker build "${PLATFORM_BUILD_ARGS[@]}" \
+            -f "${REPO_ROOT}/${RUNNER_DOCKERFILE}" \
+            -t "${RUNNER_IMAGE}" \
+            "${REPO_ROOT}"
+    fi
+fi
+
+# --- assemble act invocation -----------------------------------------------
+# -P maps the workflow's `runs-on: ubuntu-latest` to our local Node-enabled
+# image. This overrides the mapping in .actrc.
+ACT_ARGS=("${EVENT}" -W "${WORKFLOW}" --concurrent-jobs "${CONCURRENCY}")
+ACT_ARGS+=(-P "ubuntu-latest=${RUNNER_IMAGE}")
+# Note: --pull=false lives in .actrc so act does not try to force-pull the
+# local-only runner image from a registry.
+if [[ ${#ACT_ARCH_ARGS[@]} -gt 0 ]]; then
+    ACT_ARGS+=("${ACT_ARCH_ARGS[@]}")
+fi
+
+# Restrict to a single Python version when requested.
+if [[ -n "${PY_VERSION}" ]]; then
+    ACT_ARGS+=(--matrix "python-version:${PY_VERSION}")
+fi
+
+if [[ "${LIST_ONLY}" -eq 1 ]]; then
+    ACT_ARGS+=(--list)
+fi
+
+if [[ ${#EXTRA_ARGS[@]} -gt 0 ]]; then
+    ACT_ARGS+=("${EXTRA_ARGS[@]}")
+fi
+
+cd "${REPO_ROOT}"
+
+echo "==> Running CI locally via act"
+echo "    workflow:    ${WORKFLOW}"
+echo "    runner:      ${RUNNER_IMAGE}"
+echo "    event:       ${EVENT}"
+if [[ -n "${PY_VERSION}" ]]; then
+    echo "    matrix:      python-version:${PY_VERSION} (single build)"
+else
+    echo "    matrix:      3.10, 3.11, 3.12, 3.13 (up to ${CONCURRENCY} concurrent)"
+fi
+echo "    act:         act ${ACT_ARGS[*]}"
+echo
+
+exec act "${ACT_ARGS[@]}"

--- a/src/famly_fetch/cli.py
+++ b/src/famly_fetch/cli.py
@@ -63,6 +63,16 @@ def get_version():
     help="Download all images from all posts (in the feed)",
 )
 @click.option(
+    "--include-files",
+    is_flag=True,
+    help="Also download non-image file attachments (PDFs, docs, etc.) from messages, notes, and journeys",
+)
+@click.option(
+    "--include-videos",
+    is_flag=True,
+    help="Also download videos from learning journey observations and feed posts",
+)
+@click.option(
     "-p",
     "--pictures-folder",
     envvar="FAMLY_PICTURES_FOLDER",
@@ -150,6 +160,8 @@ def main(
     messages: bool,
     liked: bool,
     feed: bool,
+    include_files: bool,
+    include_videos: bool,
     pictures_folder: Path,
     stop_on_existing: bool,
     user_agent: str,
@@ -193,6 +205,8 @@ def main(
             latitude=latitude,
             longitude=longitude,
             filename_pattern=filename_pattern,
+            include_files=include_files,
+            include_videos=include_videos,
         )
 
         if messages:

--- a/src/famly_fetch/downloader.py
+++ b/src/famly_fetch/downloader.py
@@ -23,7 +23,9 @@ import piexif
 import piexif.helper
 
 from famly_fetch.api_client import ApiClient
+from famly_fetch.file import File
 from famly_fetch.image import BaseImage, Image, SecretImage
+from famly_fetch.video import Video
 
 
 class FamlyDownloader:
@@ -41,6 +43,8 @@ class FamlyDownloader:
         latitude: float | None = None,
         longitude: float | None = None,
         filename_pattern: str = "%FP-%Y-%m-%d_%H-%M-%S-%ID",
+        include_files: bool = False,
+        include_videos: bool = False,
     ):
         self._pictures_folder: Path = pictures_folder
         self._pictures_folder.mkdir(parents=True, exist_ok=True)
@@ -51,6 +55,8 @@ class FamlyDownloader:
         self.text_comments = text_comments
         self.filename_pattern = filename_pattern
         self.state_file = state_file
+        self.include_files = include_files
+        self.include_videos = include_videos
         self.downloaded_images = self.load_state()
 
         self._apiClient = ApiClient(
@@ -133,6 +139,15 @@ class FamlyDownloader:
                     self.fetch_image(img, file_path)
                     self.mark_as_downloaded(img.img_id)
 
+                if self.include_files:
+                    if self._download_files_from_item(
+                        note.get("files") or [],
+                        date=date,
+                        text=text,
+                        filename_prefix=f"{first_name}-note",
+                    ):
+                        return
+
             next_ref = batch["next"]
 
             if not next_ref:
@@ -182,6 +197,24 @@ class FamlyDownloader:
                             continue
                     self.fetch_image(img, file_path)
                     self.mark_as_downloaded(img.img_id)
+
+                if self.include_files:
+                    if self._download_files_from_item(
+                        observation.get("files") or [],
+                        date=date,
+                        text=text,
+                        filename_prefix=f"{first_name}-journey",
+                    ):
+                        return
+
+                if self.include_videos:
+                    if self._download_videos_from_item(
+                        observation.get("videos") or [],
+                        date=date,
+                        text=text,
+                        filename_prefix=f"{first_name}-journey",
+                    ):
+                        return
 
             next_cursor = batch["next"]
 
@@ -235,7 +268,6 @@ class FamlyDownloader:
             for msg in reversed(conversation["messages"]):
                 text = msg["body"] + " - " + msg["author"]["title"]
                 date = msg["createdAt"]
-
                 for img_dict in msg["images"]:
                     img = Image.from_dict(
                         img_dict,
@@ -259,6 +291,14 @@ class FamlyDownloader:
                     self.fetch_image(img, file_path)
                     self.mark_as_downloaded(img.img_id)
 
+                if self.include_files:
+                    if self._download_files_from_item(
+                        msg.get("files") or [],
+                        date=date,
+                        text=text,
+                        filename_prefix="message",
+                    ):
+                        return
         self.save_state()
 
     def download_images_from_feed(self, liked_by_ids: set[str]):
@@ -312,6 +352,24 @@ class FamlyDownloader:
                     self.fetch_image(img, file_path)
                     self.mark_as_downloaded(img.img_id)
 
+                feed_text = feed_item.get("body") if self.text_comments else None
+                if self.include_files:
+                    if self._download_files_from_item(
+                        feed_item.get("files") or [],
+                        date=create_date,
+                        text=feed_text,
+                        filename_prefix="post",
+                    ):
+                        return
+                if self.include_videos:
+                    if self._download_videos_from_item(
+                        feed_item.get("videos") or [],
+                        date=create_date,
+                        text=feed_text,
+                        filename_prefix="post",
+                    ):
+                        return
+
         self.save_state()
 
     def download_all_images_from_feed(self, batch_size=20, batch_pause=10):
@@ -362,6 +420,164 @@ class FamlyDownloader:
                             fg="cyan",
                         )
                         time.sleep(batch_pause)
+
+                feed_text = feed_item.get("body") if self.text_comments else None
+                if self.include_files:
+                    if self._download_files_from_item(
+                        feed_item.get("files") or [],
+                        date=create_date,
+                        text=feed_text,
+                        filename_prefix="post",
+                    ):
+                        return
+                if self.include_videos:
+                    if self._download_videos_from_item(
+                        feed_item.get("videos") or [],
+                        date=create_date,
+                        text=feed_text,
+                        filename_prefix="post",
+                    ):
+                        return
+
+    def _download_files_from_item(
+        self,
+        file_dicts: list,
+        date: str,
+        text: str | None,
+        filename_prefix: str,
+    ) -> bool:
+        """Download every File attachment on a single note/observation/message.
+
+        Returns True if the caller should stop (only when stop_on_existing is
+        set and an already-downloaded file is encountered)."""
+        for file_dict in file_dicts:
+            f = File.from_dict(
+                file_dict,
+                date_override=date,
+                text_override=text if self.text_comments else None,
+            )
+            click.echo(f" - file {f.file_id} ({f.name or '?'}) at {f.date}")
+
+            if f.file_id in self.downloaded_images:
+                click.secho(
+                    f"File {f.file_id} already downloaded, "
+                    f"{'stopping download' if self.stop_on_existing else 'skipping'}.",
+                    fg="yellow",
+                )
+                if self.stop_on_existing:
+                    return True
+                continue
+
+            file_path = self.attachment_path(
+                attachment_id=f.file_id,
+                attachment_url=f.url,
+                date=f.date,
+                filename_prefix=filename_prefix,
+                original_name=f.name,
+            )
+            self.fetch_binary(f.url, file_path)
+            self.mark_as_downloaded(f.file_id)
+        return False
+
+    def _download_videos_from_item(
+        self,
+        video_dicts: list,
+        date: str,
+        text: str | None,
+        filename_prefix: str,
+    ) -> bool:
+        """Download every Video attachment on a single observation.
+
+        Returns True if the caller should stop (stop_on_existing semantics)."""
+        for video_dict in video_dicts:
+            try:
+                v = Video.from_dict(
+                    video_dict,
+                    date_override=date,
+                    text_override=text if self.text_comments else None,
+                )
+            except (KeyError, ValueError) as e:
+                click.secho(
+                    f"Skipping unrecognised video dict ({sorted(video_dict.keys())}): {e}",
+                    fg="yellow",
+                )
+                continue
+            if v is None:
+                click.secho(
+                    f"Skipping video {video_dict.get('videoId', '?')} — no playable URL yet.",
+                    fg="yellow",
+                )
+                continue
+
+            click.echo(f" - video {v.video_id} at {v.date}")
+
+            if v.video_id in self.downloaded_images:
+                click.secho(
+                    f"Video {v.video_id} already downloaded, "
+                    f"{'stopping download' if self.stop_on_existing else 'skipping'}.",
+                    fg="yellow",
+                )
+                if self.stop_on_existing:
+                    return True
+                continue
+
+            file_path = self.attachment_path(
+                attachment_id=v.video_id,
+                attachment_url=v.url,
+                date=v.date,
+                filename_prefix=filename_prefix,
+                original_name=None,
+            )
+            self.fetch_binary(v.url, file_path)
+            self.mark_as_downloaded(v.video_id)
+        return False
+
+    def attachment_path(
+        self,
+        attachment_id: str,
+        attachment_url: str,
+        date: datetime,
+        filename_prefix: str,
+        original_name: str | None,
+    ) -> Path:
+        """Pick a destination path for a non-image attachment (file or video).
+
+        Uses the original filename if available (sanitised, with date prefix
+        for sortability and id suffix to disambiguate); otherwise falls back
+        to the same filename pattern images use, with the extension derived
+        from the URL path."""
+        date_dir = date.strftime("%Y-%m-%d")
+        dir_path = Path(self._pictures_folder, date_dir)
+        dir_path.mkdir(parents=True, exist_ok=True)
+
+        if original_name:
+            safe = (
+                "".join(
+                    c if c.isalnum() or c in "-_." else "_" for c in original_name
+                ).strip("._")
+                or attachment_id
+            )
+            stem, ext = os.path.splitext(safe)
+            filename = (
+                f"{filename_prefix}-{date.strftime('%Y-%m-%d_%H-%M-%S')}"
+                f"-{attachment_id}-{stem}{ext}"
+            )
+        else:
+            ext = os.path.splitext(urlparse(attachment_url).path)[1].lower()
+            filename = self.filename_pattern
+            filename = filename.replace("%FP", filename_prefix)
+            filename = filename.replace("%ID", attachment_id)
+            filename = date.strftime(filename) + ext
+        return Path(dir_path, filename)
+
+    def fetch_binary(self, url: str, file_path: Path):
+        """Stream a URL to disk. Used for non-image attachments where EXIF
+        injection doesn't apply."""
+        req = urllib.request.Request(url=url)
+        with urllib.request.urlopen(req) as r, open(file_path, "wb") as f:
+            if r.status != 200:
+                raise Exception(f"Broken! {r.read().decode('utf-8')}")
+            shutil.copyfileobj(r, f)
 
     def download_file_path(self, img: BaseImage, filename_prefix: str) -> Path:
         """Generate the file path for the downloaded image."""

--- a/src/famly_fetch/file.py
+++ b/src/famly_fetch/file.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class File:
+    file_id: str
+    url: str
+    date: datetime
+    name: str | None
+    text: str | None
+
+    @staticmethod
+    def from_dict(
+        data: dict, date_override: str, text_override: str | None = None
+    ) -> "File":
+        return File(
+            file_id=data["fileId"],
+            url=data["url"],
+            date=datetime.fromisoformat(date_override),
+            name=data.get("filename"),
+            text=text_override,
+        )

--- a/src/famly_fetch/graphql/GetChildNotes.graphql
+++ b/src/famly_fetch/graphql/GetChildNotes.graphql
@@ -40,4 +40,9 @@ fragment Note on ChildNote {
     }
     width
   }
+  files {
+    fileId: id
+    url
+    filename: name
+  }
 }

--- a/src/famly_fetch/graphql/LearningJourneyQuery.graphql
+++ b/src/famly_fetch/graphql/LearningJourneyQuery.graphql
@@ -46,15 +46,20 @@ fragment ObservationDataWithNoComments on Observation {
   }
   videos {
     ... on TranscodingVideo {
-      id
+      videoId: id
     }
     ... on TranscodedVideo {
       duration
       height
-      id
+      videoId: id
       thumbnailUrl
       videoUrl
       width
     }
+  }
+  files {
+    fileId: id
+    url
+    filename: name
   }
 }

--- a/src/famly_fetch/video.py
+++ b/src/famly_fetch/video.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class Video:
+    video_id: str
+    url: str
+    date: datetime
+    text: str | None
+
+    @staticmethod
+    def from_dict(
+        data: dict, date_override: str, text_override: str | None = None
+    ) -> "Video | None":
+        url = data.get("videoUrl")
+        if not url:
+            return None
+        return Video(
+            video_id=data["videoId"],
+            url=url,
+            date=datetime.fromisoformat(date_override),
+            text=text_override,
+        )


### PR DESCRIPTION
The Famly API exposes file attachments (PDFs, docs, etc.) and videos on notes, observations, messages, and feed posts, which I wanted to retain alongside the images. This commit adds two flags without changing the default behaviour:

    --include-files   Pulls files from notes, observations, messages,
                      and feed posts (every source where the API exposes
                      them).
    --include-videos  Pulls videos from observations and feed posts.
                      Notes/messages don't expose a videos field, so
                      those sources are no-ops here.

Implementation notes:

  - New File and Video dataclasses in their own modules, mirroring image.py.
  - Downloads share the existing state.json: file/video ids land in the same flat dict as image ids, so resume and --stop-on-existing work uniformly across all three media types.
  - Files and videos save into the same YYYY-MM-DD/ folder as images. When the API supplies an original filename it's preserved (sanitised + date-prefixed + id-suffixed); otherwise the existing --filename-pattern fallback applies.
  - A new fetch_binary helper streams URLs to disk without the EXIF rewriting fetch_image does, since neither files nor videos are JPEG/TIFF.
  - TranscodingVideo entries (still processing, no playable URL) are skipped with a warning rather than treated as a hard error.

Other consideration:

Raised the pull request because this functionality seems consistent with the intent of famly-fetch (makes sense that you might want to fetch other files - videos in particular). But the behaviour/internals of the codebase are otherwise very image-centric. I have fitted these changes alongside the default behaviour. An alternative approach would be to reduce the image-centricity of famly-fetch to make it a more generic fetching tool with flags for image, file, video, etc. rather than assuming image by default. But this is a bigger change in direction/architecture.

## Local CI harness

To reproduce the GitHub Actions workflow (`.github/workflows/ci.yml`) on a developer machine before pushing, this also adds `scripts/ci-local.sh`, a wrapper around [`act`](https://github.com/nektos/act) that runs the full Python version matrix (3.10 to 3.13) as concurrent container builds, executing the same lint and `ruff format` steps CI does, so a failure here matches what GitHub reports.

  - `ci-local.Dockerfile` extends the standard `act` runner with Node.js 24, which the stock catthehacker image no longer ships; the checkout and setup-python actions need `node` for their JS steps.
  - `.actrc` maps `ubuntu-latest` to that local image and disables registry pulls for it.
  - README gains a "Running CI Locally" section, documentation for the new `--include-files` / `--include-videos` flags, and a refreshed `--help` listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code), models: Claude Opus 4.8 (1M context)
